### PR TITLE
Refactor for readability and Pythonic code styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+temp_image.jpg

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # HexBot
-Twitter bot that posts colors from #000000 to #FFFFFF every 15 minutes.
+> Twitter bot that posts colors from `#000000` to `#FFFFFF` every 15 minutes.
+
+
+## Installation
+
+Install Python 3.
+
+Install system dependencies - this is recommended to be done inside a _virtual environment_.
+
+```sh
+pip install -r requirements.txt
+```
+
+
+## Config
+
+Set environment variables.
+
+
+### Twitter credentials
+
+- `CONSUMER_TOKEN`
+- `CONSUMER_SECRET`
+- `ACCESS_TOKEN`
+- `ACCESS_TOKEN_SECRET`
+
+### Redis credentials
+
+- `HOST`
+- `PASSWORD`
+
+
+## Usage
+
+```sh
+python main.py
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 ```
 
 
-## Config
+## Configure
 
 Set environment variables.
 

--- a/main.py
+++ b/main.py
@@ -13,7 +13,8 @@ api = tweepy.API(auth)
 r = redis.Redis(
     host=os.environ["HOST"],
     port=7839,
-    password=os.environ["PASSWORD"])
+    password=os.environ["PASSWORD"]
+)
 
 def main():
     global color_number

--- a/main.py
+++ b/main.py
@@ -24,8 +24,12 @@ def main():
         for i in range(format_length): #Adds 0 if needed
             hex_number = "0" + hex_number
 
-        media_url = f"http://www.singlecolorimage.com/get/{hex_number}/500x500.png" # Path to image
-        urllib.request.urlretrieve(media_url, "temp_image.jpg")
+        media_url = f"http://www.singlecolorimage.com/get/{hex_number}/500x500.png"
+        try:
+            urllib.request.urlretrieve(media_url, "temp_image.jpg")
+        except urllib.error.HTTPError:
+            print(f"Hex value: {hex_number}")
+            raise
 
         api.update_with_media("temp_image.jpg", status="#" + hex_number)
         print(media_url)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
-import tweepy
-import redis
+import os
 import time
 import urllib.request
-import os
+
+import redis
+import tweepy
+
 
 auth = tweepy.OAuthHandler(os.environ["CONSUMER_TOKEN"], os.environ["CONSUMER_SECRET"]) # Place consumer_token and consumer_secret
 auth.set_access_token(os.environ["ACCESS_TOKEN"], os.environ["ACCESS_TOKEN_SECRET"]) # Place access_token and access_token_secret

--- a/main.py
+++ b/main.py
@@ -6,8 +6,12 @@ import redis
 import tweepy
 
 
-auth = tweepy.OAuthHandler(os.environ["CONSUMER_TOKEN"], os.environ["CONSUMER_SECRET"]) # Place consumer_token and consumer_secret
-auth.set_access_token(os.environ["ACCESS_TOKEN"], os.environ["ACCESS_TOKEN_SECRET"]) # Place access_token and access_token_secret
+# This is stored as an `int`.
+MAX_HEX = 0xffffff
+
+
+auth = tweepy.OAuthHandler(os.environ["CONSUMER_TOKEN"], os.environ["CONSUMER_SECRET"])
+auth.set_access_token(os.environ["ACCESS_TOKEN"], os.environ["ACCESS_TOKEN_SECRET"])
 api = tweepy.API(auth)
 
 r = redis.Redis(
@@ -16,14 +20,11 @@ r = redis.Redis(
     password=os.environ["PASSWORD"]
 )
 
-def main():
-    global color_number
-    while color_number < 16777216: # Till last possible hex number
-        hex_number = str(hex(color_number))[2:]
-        format_length = 6 - len(hex_number)
 
-        for i in range(format_length): #Adds 0 if needed
-            hex_number = "0" + hex_number
+def main(color_number=0):
+    while color_number < MAX_HEX:
+        # 6-digit zero padded hex string. e.g. "012def"
+        hex_number = f"{color_number:06x}"
 
         media_url = f"http://www.singlecolorimage.com/get/{hex_number}/500x500.png"
         try:
@@ -32,14 +33,14 @@ def main():
             print(f"Hex value: {hex_number}")
             raise
 
-        api.update_with_media("temp_image.jpg", status="#" + hex_number)
+        api.update_with_media("temp_image.jpg", status=f"#{hex_number}")
         print(media_url)
         r.incr('num')
         color_number = int(r.get("num"))
-        time.sleep(15 * 60) # Posts every 15 minutes
-
+        # Posts every 15 minutes.
+        time.sleep(15 * 60)
 
 
 if __name__ == "__main__":
     color_number = int(r.get("num"))
-    main()
+    main(color_number)

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ api = tweepy.API(auth)
 
 r = redis.Redis(
     host=os.environ["HOST"],
-    port=7839, 
+    port=7839,
     password=os.environ["PASSWORD"])
 
 def main():
@@ -25,7 +25,7 @@ def main():
             hex_number = "0" + hex_number
 
         media_url = f"http://www.singlecolorimage.com/get/{hex_number}/500x500.png" # Path to image
-        urllib.request.urlretrieve(media_url, "temp_image.jpg")            
+        urllib.request.urlretrieve(media_url, "temp_image.jpg")
 
         api.update_with_media("temp_image.jpg", status="#" + hex_number)
         print(media_url)
@@ -38,4 +38,3 @@ def main():
 if __name__ == "__main__":
     color_number = int(r.get("num"))
     main()
-


### PR DESCRIPTION
Improvements

- I refactored hex number handling to be done in one line. Example:
    ```python
    >>> color_number = 12525
    >>> f"{color_number:06x}"
    '0030ed'
    ```
    Read a detailed explanation in my [cheatsheet](https://github.com/MichaelCurrin/cheatsheets/blob/master/cheatsheets/python/strings.md#hex-color-code).
- I added some setup instructions.
- I added error handling to print the URL before re-raising a bad request error.
- Reorderd imports.
- Removed used of global variable.